### PR TITLE
Don't specify the type of this

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,6 @@ export interface Emitter<Events extends EventsMap = DefaultEvents> {
    * @param args The arguments for listeners.
    */
   emit<K extends keyof Events>(
-    this: this,
     event: K,
     ...args: Parameters<Events[K]>
   ): void
@@ -54,7 +53,7 @@ export interface Emitter<Events extends EventsMap = DefaultEvents> {
    * @param cb The listener function.
    * @returns Unbind listener from event.
    */
-  on<K extends keyof Events>(this: this, event: K, cb: Events[K]): Unsubscribe
+  on<K extends keyof Events>(event: K, cb: Events[K]): Unsubscribe
 }
 
 /**

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -35,9 +35,3 @@ typed.events = {
 let untyped = createNanoEvents()
 // THROWS not assignable to parameter of type '(...args: any) => void'
 untyped.on('test', 1)
-
-const { on, emit } = typed
-// THROWS is not assignable to method's 'this' of type
-on('tick', () => {})
-// THROWS is not assignable to method's 'this' of type
-emit('tick')


### PR DESCRIPTION
So that `Emitter['on']` can be used to type mixins.

Resolves https://github.com/ai/nanoevents/issues/72
